### PR TITLE
Do not send location to Upload wizard

### DIFF
--- a/wlm-maps.js
+++ b/wlm-maps.js
@@ -124,7 +124,7 @@ function setMarker(feature,latlng) {
     }
     var thumb_url = '//upload.wikimedia.org/wikipedia/commons/thumb/' + feature.properties.md5.substring(0,1) + '/' + feature.properties.md5.substring(0,2) + '/' + feature.properties.image + '/150px-' + feature.properties.image;
     popuptext = popuptext + '<tr><td valign=top><b>ID:</b> '+feature.properties.id+'<br/><b>Country:</b> '+feature.properties.country+'</td><td><a href="//commons.wikimedia.org/wiki/File:'+feature.properties.image+'" target="_blank"><img src="'+thumb_url+'" /></a></td></tr>';
-    popuptext = popuptext + '<tr><td colspan=2 style="text-align: center;font-size: 150%;"><a href="//commons.wikimedia.org/w/index.php?title=Special:UploadWizard&campaign=wlm-'+feature.properties.country+'&id='+feature.properties.id+'&lat='+feature.geometry.coordinates[0]+'&lon='+feature.geometry.coordinates[1]+'" target="_blank"><b>Upload your photo!</b></a></td></tr>';
+    popuptext = popuptext + '<tr><td colspan=2 style="text-align: center;font-size: 150%;"><a href="//commons.wikimedia.org/w/index.php?title=Special:UploadWizard&campaign=wlm-'+feature.properties.country+'&id='+feature.properties.id+'" target="_blank"><b>Upload your photo!</b></a></td></tr>';
     if (feature.properties.commonscat)
     {
         popuptext = popuptext + '<tr><td colspan=2 style="text-align: center;">(<a href="//commons.wikimedia.org/wiki/Category:'+feature.properties.commonscat+'" target="_blank">More images in Commons</a>)</td></tr>';


### PR DESCRIPTION
Object location should not be sent to the Upload Wizard since
this gets interpreted as camera location. Instead these will
be added by ErgoedBot afterwards.

Bugzilla: https://bugzilla.wikimedia.org/show_bug.cgi?id=70437
Github issue #5 

Similar correction has also been made to some lists e.g. https://sv.wikipedia.org/w/index.php?title=Mall%3ABBR&diff=27433296&oldid=24654514
